### PR TITLE
Document needed dependencies in Ivy format (https://ant.apache.org/ivy/)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Use this script with 'ant -f build.xml' or simply 'ant'.
+-->
+<project name="open-mensa-android" default="default" basedir="."
+    xmlns:ivy="antlib:org.apache.ivy.ant">
+    
+    <target name="default" depends="resolve"/>
+
+    <target name="init">
+        <property name="lib.dir" value="libs"/>
+    </target>
+    
+    <target name="resolve" depends="init" description="Retrieve dependencies">
+        <mkdir dir="${lib.dir}"/>
+        
+        <ivy:retrieve pattern="${lib.dir}/[artifact]-[revision]-[type].[ext]"/>
+    </target>
+</project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
+    <info organisation="de.uni_potsdam.hpi" module="openmensa"/>
+    <publications>
+        <!-- no artifacts -->
+    </publications>
+    <dependencies>
+        <!--
+        	Download this via the SDK manager or in Eclipse go to
+        	[Project] -> [Android Tools] -> [Add support library].
+        	<dependency org="com.google.android" name="support-v4" rev="r10"/>
+        -->
+        <dependency org="com.google.code.gson" name="gson" rev="2.2.2"/>
+
+        <!-- strip all Javadoc and sources -->
+        <exclude org="*" ext="*" type="javadoc"/>
+        <exclude org="*" ext="*" type="source"/>
+    </dependencies>
+</ivy-module>


### PR DESCRIPTION
Ivy relies on Maven infrastructure to download libraries, see
mvnrepository.com.
