### PR TITLE
Ignore canteens without coordinates in selection of favorite canteens

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="powered_by_title">Powered by</string>
     <string name="powered_by_desc">OpenMensa</string>
     <string name="author_title">Author</string>
-    <string name="author_desc">Dominik Moritz, Christian Nicolai, Jan Graichen, Jan Renz</string>
+    <string name="author_desc">Dominik Moritz, Christian Nicolai, Jan Graichen, Jan Renz, Matthias Jacob</string>
     <string name="feedback_title">Feedback</string>
     <string name="feedback_desc">Write me a short email and ask a question, thank me or complain.</string>
     <string name="settings_design_title">Design</string>

--- a/src/de/uni_potsdam/hpi/openmensa/api/preferences/SelectFavouritesPreference.java
+++ b/src/de/uni_potsdam/hpi/openmensa/api/preferences/SelectFavouritesPreference.java
@@ -81,7 +81,18 @@ public class SelectFavouritesPreference extends MultiSelectListPreference {
     	//entryValuesList.add("#ALL#");
     	
     	List<Canteen> orderedCanteens = new ArrayList<Canteen>(canteens.values());
-    	
+
+        // remove canteens that have not set their coordinates properly
+        List<Canteen> canteensToRemove = new ArrayList<Canteen>();
+        for (Canteen canteen : orderedCanteens) {
+            if (canteen.coordinates == null || canteen.coordinates.length < 2
+                || canteen.coordinates[0] == null || canteen.coordinates[1] == null) {
+
+                canteensToRemove.add(canteen);
+            }
+        }
+        orderedCanteens.removeAll(canteensToRemove);
+
     	location = getLastBestLocation();
     	
     	if (location != null) {

--- a/src/de/uni_potsdam/hpi/openmensa/api/preferences/SelectFavouritesPreference.java
+++ b/src/de/uni_potsdam/hpi/openmensa/api/preferences/SelectFavouritesPreference.java
@@ -85,7 +85,7 @@ public class SelectFavouritesPreference extends MultiSelectListPreference {
         // remove canteens that have not set their coordinates properly
         List<Canteen> canteensToRemove = new ArrayList<Canteen>();
         for (Canteen canteen : orderedCanteens) {
-            if (canteen.coordinates == null || canteen.coordinates.length < 2
+            if (canteen.coordinates == null || canteen.coordinates.length != 2
                 || canteen.coordinates[0] == null || canteen.coordinates[1] == null) {
 
                 canteensToRemove.add(canteen);


### PR DESCRIPTION
As discussed in #25, we need to remove canteens without coordinates from further consideration. This PR ensures that only those canteens are processed for the fav canteen selection that meet some basic criteria (coordinates present, at least 2 entries [lat/lon], none of them null).