### PR TITLE
add suffix ".debug" to application id when debugging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ android {
                 debuggable false
                 signingConfig signingConfigs.release
             }
+            debug {
+                applicationIdSuffix ".debug"
+            }
         }
     }
 }


### PR DESCRIPTION
With a different suffix for the application id, the application
installed from Play Store will not be overwritten by the debug
version.