### PR TITLE
Fixes UI thread exception on updating mensa data

### DIFF
--- a/src/de/uni_potsdam/hpi/openmensa/MainActivity.java
+++ b/src/de/uni_potsdam/hpi/openmensa/MainActivity.java
@@ -246,7 +246,7 @@ public class MainActivity extends SherlockFragmentActivity implements
 					fragment.setToFetching(true, !fragment.isListShown());
 					String baseUrl = SettingsUtils.getSourceUrl(MainActivity.context);
 					String url = baseUrl + "canteens/" + canteen.key + "/meals/?start=" + dateString;
-					RetrieveFeedTask task = new RetrieveDaysFeedTask(MainActivity.context, this, canteen, dateString);
+					RetrieveFeedTask task = new RetrieveDaysFeedTask(MainActivity.context, this, this, canteen, dateString);
 					task.execute(new String[] { url });
 					startedFetching = true;
 					setProgressBarIndeterminateVisibility(Boolean.TRUE);
@@ -332,7 +332,7 @@ public class MainActivity extends SherlockFragmentActivity implements
 		String baseUrl = SettingsUtils.getSourceUrl(this);
 		String url = baseUrl + "canteens" + "?limit=50";
 
-		RetrieveFeedTask task = new RetrieveCanteenFeedTask(this, this, url);
+		RetrieveFeedTask task = new RetrieveCanteenFeedTask(this, this, this, url);
 		task.execute(url);
 	}
 

--- a/src/de/uni_potsdam/hpi/openmensa/RetrieveCanteenFeedTask.java
+++ b/src/de/uni_potsdam/hpi/openmensa/RetrieveCanteenFeedTask.java
@@ -1,5 +1,6 @@
 package de.uni_potsdam.hpi.openmensa;
 
+import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import de.uni_potsdam.hpi.openmensa.api.Canteen;
@@ -20,8 +21,8 @@ public class RetrieveCanteenFeedTask extends RetrieveFeedTask {
 	private int currentPage = 1;
 	private String url;
 	
-	public RetrieveCanteenFeedTask(Context context, OnFinishedFetchingCanteensListener fetchListener, String url) {
-		super(context);
+	public RetrieveCanteenFeedTask(Context context, Activity activity, OnFinishedFetchingCanteensListener fetchListener, String url) {
+		super(context, activity);
 		
 		this.url = url;
 		this.canteens = new Canteens();

--- a/src/de/uni_potsdam/hpi/openmensa/RetrieveDaysFeedTask.java
+++ b/src/de/uni_potsdam/hpi/openmensa/RetrieveDaysFeedTask.java
@@ -1,5 +1,6 @@
 package de.uni_potsdam.hpi.openmensa;
 
+import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import de.uni_potsdam.hpi.openmensa.api.Canteen;
@@ -20,8 +21,8 @@ public class RetrieveDaysFeedTask extends RetrieveFeedTask {
 	protected Canteen canteen;
 	public String dateString = "";
 
-	public RetrieveDaysFeedTask(Context context, OnFinishedFetchingDaysListener fetchListener, Canteen canteen, String dateString) {
-		super(context);
+	public RetrieveDaysFeedTask(Context context, Activity activity, OnFinishedFetchingDaysListener fetchListener, Canteen canteen, String dateString) {
+		super(context, activity);
 		this.dateString = dateString;
 		this.canteen = canteen;
 		this.fetchListener = fetchListener;

--- a/src/de/uni_potsdam/hpi/openmensa/RetrieveMealFeedTask.java
+++ b/src/de/uni_potsdam/hpi/openmensa/RetrieveMealFeedTask.java
@@ -2,6 +2,7 @@ package de.uni_potsdam.hpi.openmensa;
 
 import java.util.ArrayList;
 
+import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import de.uni_potsdam.hpi.openmensa.api.Canteen;
@@ -21,8 +22,8 @@ public class RetrieveMealFeedTask extends RetrieveFeedTask {
 	protected Canteen canteen;
 	private String date;
 
-	public RetrieveMealFeedTask(Context context, OnFinishedFetchingMealsListener fetchListener, Canteen canteen, String date) {
-		super(context);
+	public RetrieveMealFeedTask(Context context, Activity activity, OnFinishedFetchingMealsListener fetchListener, Canteen canteen, String date) {
+		super(context, activity);
 		this.mealList = new ArrayList<Meal>();
 		this.canteen = canteen;
 		this.date = date;

--- a/src/de/uni_potsdam/hpi/openmensa/helpers/RetrieveFeedTask.java
+++ b/src/de/uni_potsdam/hpi/openmensa/helpers/RetrieveFeedTask.java
@@ -47,7 +47,10 @@ public abstract class RetrieveFeedTask extends AsyncTask<String, Integer, Void> 
 
 	private final int DEFAULT_BUFFER_SIZE = 1024;
 
-	public RetrieveFeedTask(Context context) {
+    private Activity mActivity;
+
+	public RetrieveFeedTask(Context context, Activity activity) {
+        mActivity = activity;
 		// progress dialog
 		dialog = new ProgressDialog(context);
 		dialog.setTitle("Fetching ...");
@@ -107,7 +110,13 @@ public abstract class RetrieveFeedTask extends AsyncTask<String, Integer, Void> 
 			// content length is sometimes not sent
 			if (visible) {
 				if (fileLength < 0) {
-					dialog.setIndeterminate(true);
+                    mActivity.runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            dialog.setIndeterminate(true);
+                        }
+                    });
+
 				} else {
 					dialog.setMax((int) fileLength);
 				}


### PR DESCRIPTION
RetrieveFeedTask: run dialog.setIndeterminate(true) on UI thread, fixes #33

I'm not sure, if i really understood the problem and probably this is more a bad hack than a good solution, but it seems to work and makes the app usable on Android 7.1.1...

Please consider, if you want to merge this into your master or wait, until someone provides a better solution for this problem. Unfortunately I don't think i will find time to dig deeper into the problem in the next weeks. 